### PR TITLE
Исправление имени тега для авто-релизов

### DIFF
--- a/.github/workflows/makerelease.yml
+++ b/.github/workflows/makerelease.yml
@@ -1,4 +1,4 @@
-name: Build & Run all tests (release) & Make an unstable release
+﻿name: Build & Run all tests (release) & Make an unstable release
 
 on:
   push:
@@ -64,7 +64,7 @@ jobs:
                         await github.rest.git.deleteRef({
                             owner: owner,
                             repo: repo,
-                            ref: 'tags/refactoring-build'
+                            ref: `tags/${tag}`
                         });
                         console.log('Tag deleted successfully');
                     } catch (error) {


### PR DESCRIPTION
Только сейчас заметил 1 проблему - новые установщики заливаются, но тег показывает не на том коммите.
Если посмотреть сейчас сюда: https://github.com/AlexanderZemlyak/pascalabcnet/releases/tag/refactoring-build-tag
Показывается что исходный код существовал на 2 часа дольше чем установщики, хотя создание установщиков происходит за 15-20 мин.
И в GitKraken показывает что тег не на том коммите - это я в первую очередь заметил.

Проблема в том что я поменял имя тега в 1 месте, но тогда ещё не везде использовал переменную `tag` - поэтому в коде который удаляет старый тег перед созданием нового релиза - этот старый тег не смогло удалить.
https://github.com/AlexanderZemlyak/pascalabcnet/actions/runs/7173405366/job/19532694191#step:5:155
Остальное сработало правильно - но в итоге залило установщики в старый тег, который остался на старом коммите.

Теперь протестил у себя на ветке (второй пустой коммит для этого) - старый тег удаляется как ожидалось при добавлении коммитов.